### PR TITLE
Multiple admins, mark not registered users

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -9,6 +9,12 @@ const debug = require('debug')('cloud-client:server')
 const http = require('http')
 
 /**
+ * Separate admin emails into a list of emails.
+ */
+
+process.env.ADMIN_EMAILS = process.env.ADMIN_EMAIL.split(',')
+
+/**
  * Get port from environment and store in Express.
  */
 

--- a/bin/www
+++ b/bin/www
@@ -1,43 +1,32 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
+// Module dependencies.
+
 require('dotenv').load()
 const app = require('../app')
 const debug = require('debug')('cloud-client:server')
 const http = require('http')
 
-/**
- * Separate admin emails into a list of emails.
- */
+// Separate admin emails into a list of emails.
 
 process.env.ADMIN_EMAILS = process.env.ADMIN_EMAIL.split(',')
 
-/**
- * Get port from environment and store in Express.
- */
+// Get port from environment and store in Express.
 
 const port = normalizePort(process.env.PORT || '5000')
 app.set('port', port)
 
-/**
- * Create HTTP server.
- */
+// Create HTTP server.
 
 const server = http.createServer(app)
 
-/**
- * Listen on provided port, on all network interfaces.
- */
+// Listen on provided port, on all network interfaces.
 
 server.listen(port)
 server.on('error', onError)
 server.on('listening', onListening)
 
-/**
- * Normalize a port into a number, string, or false.
- */
+// Normalize a port into a number, string, or false.
 
 function normalizePort (val) {
   const port = parseInt(val, 10)
@@ -55,9 +44,7 @@ function normalizePort (val) {
   return false
 }
 
-/**
- * Event listener for HTTP server "error" event.
- */
+// Event listener for HTTP server "error" event.
 
 function onError (error) {
   if (error.syscall !== 'listen') {
@@ -83,9 +70,7 @@ function onError (error) {
   }
 }
 
-/**
- * Event listener for HTTP server "listening" event.
- */
+// Event listener for HTTP server "listening" event.
 
 function onListening () {
   const addr = server.address()

--- a/config/admin.js
+++ b/config/admin.js
@@ -23,5 +23,9 @@ module.exports = {
     User.update({_id: userid}, {$set: {status: stat}}, function(err, raw){
       return next()
     })
+  },
+  // returns true if the email given is an admin email
+  isAdmin: function(emailAddr) {
+    return process.env.ADMIN_EMAILS.includes(emailAddr)
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -96,7 +96,7 @@ router.post('/change-password/:ident/:timestamp-:hash', function (req, res, next
 
 router.get('/home', isLoggedIn, function (req, res, next) {
   // If user is admin
-  if (req.user.local.email === process.env.ADMIN_EMAIL) {
+  if (adminFunc.isAdmin(req.user.local.email)) {
     return res.redirect('/admin')
   }
 
@@ -210,7 +210,7 @@ router.post('/not-attending-confirmation', isLoggedIn, function (req, res, next)
 })
 
 router.get('/admin', isLoggedIn, function (req, res, next) {
-  if (req.user.local.email !== process.env.ADMIN_EMAIL) {
+  if (!adminFunc.isAdmin(req.user.local.email)) {
     res.redirect('/')
     return
   }
@@ -218,7 +218,7 @@ router.get('/admin', isLoggedIn, function (req, res, next) {
 })
 
 router.get('/admin-all-registrants', isLoggedIn, function(req, res, next) {
-  if(req.user.local.email !== process.env.ADMIN_EMAIL) {
+  if (!adminFunc.isAdmin(req.user.local.email)) {
     res.redirect('/')
     return
   }
@@ -228,14 +228,13 @@ router.get('/admin-all-registrants', isLoggedIn, function(req, res, next) {
 })
 
 router.get('/changeStatus/:userid/:stat', isLoggedIn, function(req, res) {
-  if (req.user.local.email !== process.env.ADMIN_EMAIL) {
+  if (!adminFunc.isAdmin(req.user.local.email)) {
     return res.redirect('/')
   }
   adminFunc.changeStatus(req.params.userid, req.params.stat, function() {
     return res.sendStatus(200)
   })
 })
-
 
 function isLoggedIn (req, res, next) {
   debug(req)

--- a/views/pages/admin-console.ejs
+++ b/views/pages/admin-console.ejs
@@ -55,6 +55,7 @@
           <td v-else> {{ user.status }} </td>
           <td v-if='user.status == "Accepted"' style='background-color: green'> {{ user.status }} </td>
           <td v-else-if='user.status == "Denied"' style='background-color: red'> {{ user.status }} </td>
+          <td v-else-if='user.local.registered == false' style='background-color: cyan'> Not Registered </td>
           <td v-else style='background-color: #f90'> {{ user.status }} </td>
           <td> {{ user.first_name }} {{ user.last_name }} </td>
           <td v-if='user.school'> {{ user.school.name }} </td>

--- a/views/pages/admin-console.ejs
+++ b/views/pages/admin-console.ejs
@@ -46,16 +46,17 @@
       </thead>
       <tbody>
         <tr v-for="user in users">
-          <td v-if='user.status != "Not Attending"' style="min-width:150px">
+          <td v-if='user.status != "Not Attending" && user.local.registered != false' style="min-width:150px">
             <button v-on:click='changeStatus(user._id, "Accepted")'>A</button> <!-- Accept -->
             <button v-on:click='changeStatus(user._id, "Denied")'>R</button> <!-- Reject -->
             <button v-on:click='changeStatus(user._id, "Pending")'>P</button> <!-- Put on Pending -->
             <button>N</button> <!-- Notify (send email) -->
           </td>
-          <td v-else> {{ user.status }} </td>
+          <td v-else> </td>
           <td v-if='user.status == "Accepted"' style='background-color: green'> {{ user.status }} </td>
           <td v-else-if='user.status == "Denied"' style='background-color: red'> {{ user.status }} </td>
           <td v-else-if='user.local.registered == false' style='background-color: cyan'> Not Registered </td>
+          <td v-else-if='user.status == "Not Attending"' style='background-color: pink'> Not Attending </td>
           <td v-else style='background-color: #f90'> {{ user.status }} </td>
           <td> {{ user.first_name }} {{ user.last_name }} </td>
           <td v-if='user.school'> {{ user.school.name }} </td>

--- a/views/pages/admin-console.ejs
+++ b/views/pages/admin-console.ejs
@@ -46,7 +46,7 @@
       </thead>
       <tbody>
         <tr v-for="user in users">
-          <td v-if='user.status != "Not Attending" && user.local.registered != false' style="min-width:150px">
+          <td v-if='user.status != "Not Attending" && user.local.registered' style="min-width:150px">
             <button v-on:click='changeStatus(user._id, "Accepted")'>A</button> <!-- Accept -->
             <button v-on:click='changeStatus(user._id, "Denied")'>R</button> <!-- Reject -->
             <button v-on:click='changeStatus(user._id, "Pending")'>P</button> <!-- Put on Pending -->


### PR DESCRIPTION
Admin page now marks which users have registered with MLH and which users haven't. The website also now allows multiple administrator emails as such:

* in the .env instead of 
ADMIN_EMAIL=email1
* write
ADMIN_EMAIL=email1,email2,email3

This way we can all have access to the admin panel and accept/reject applicants.